### PR TITLE
Step 19 부하테스트 스크립트 작성, 개선 및 문서화

### DIFF
--- a/load-test/script.js
+++ b/load-test/script.js
@@ -1,0 +1,200 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Rate } from 'k6/metrics';
+
+const BASE_URL = 'http://localhost:3000/api';
+
+export const errorRate = new Rate('errors');
+
+export const options = {
+  stages: [
+    { duration: '10s', target: 100 }, // 선착순 판매임으로 초기 100명의 사용자가 동시에 접속
+    { duration: '5m', target: 100 }, // 입장한 사용자가 5분간 서비스에 머무름
+    { duration: '1m', target: 50 }, // 좌석 매진 후 점차적으로 사용자를 줄임
+    { duration: '1m', target: 40 },
+    { duration: '1m', target: 30 },
+    { duration: '1m', target: 20 },
+    { duration: '1m', target: 10 },
+  ],
+};
+
+export default async function () {
+  const userId = Number(__VU);
+
+  // 토큰 발급 및 진입 대기
+  const token = await queue(userId);
+
+  if (token == null) {
+    return;
+  }
+
+  // 공연 목록 조회
+  await getConcertList(token);
+
+  let seat = null;
+  let reservationId = null;
+
+  // 좌석 예약에 성공할때까지 빈좌석을 찾아서 예매하도록 반복
+  while (reservationId == null) {
+    // 공연 좌석 조회
+    const seats = await getConcertSeat(token, 1);
+    const availableSeats = seats.filter((seat) => seat['status'] === 'open');
+    if (availableSeats.length === 0) {
+      // 좌석이 없을 경우
+      return;
+    }
+
+    const randomIndex = Math.floor(Math.random() * availableSeats.length);
+    seat = availableSeats[randomIndex];
+
+    // 좌석 예약
+    reservationId = await reserveSeat(token, 1, seat['id']);
+  }
+
+  // 포인트 충전
+  await chargePoint(userId, seat['price']);
+
+  // 좌석 결제
+  await pay(token, reservationId);
+}
+
+/**
+ * 대기열 시나리오
+ * 대기열 토큰 발급을 요청하고, 발급된 토큰이 working 상태가 될때까지 대기
+ */
+function queue(userId) {
+  let res = http.post(
+    `${BASE_URL}/queue/token`,
+    JSON.stringify({
+      userId,
+    }),
+    {
+      tags: { name: '대기열 토큰 발급' },
+      headers: { 'Content-Type': 'application/json' },
+    },
+  );
+  check(res, { '대기열 토큰 발급': (r) => r.status === 201 });
+
+  if (res.status === 201) {
+    const token = res.json().token;
+
+    // 발급받은 대기열 토큰이 입장 가능할때까지 대기
+    while (true) {
+      res = http.get(`${BASE_URL}/queue/token/validate`, {
+        tags: { name: '대기열 토큰 유효성 체크' },
+        headers: {
+          Authorization: `${token}`,
+        },
+      });
+
+      if (res.status == 200 && res.json().status === 'working') {
+        check(res, { '대기열 토큰 유효성 체크': (r) => r.status === 200 });
+        return token;
+      } else if (res.status == 404) {
+        return null;
+      }
+      sleep(0.5);
+    }
+  } else {
+    return null;
+  }
+}
+
+/**
+ * 공연 목록 조회
+ */
+function getConcertList(token) {
+  const res = http.get(`${BASE_URL}/concerts`, {
+    tags: { name: '공연 목록 조회' },
+    headers: {
+      Authorization: `${token}`,
+    },
+  });
+  check(res, { '공연 목록 조회': (r) => r.status === 200 });
+}
+
+/**
+ * 공연 좌석 목록 조회
+ */
+function getConcertSeat(token, scheduleId) {
+  const res = http.get(`${BASE_URL}/concerts/schedules/${scheduleId}/seats`, {
+    tags: { name: '공연 좌석 목록 조회' },
+    headers: {
+      Authorization: `${token}`,
+    },
+  });
+  check(res, { '공연 좌석 조회': (r) => r.status === 200 });
+
+  if (res.status === 200) {
+    return res.json();
+  }
+  return [];
+}
+
+/**
+ * 좌석 예약
+ */
+function reserveSeat(token, scheduleId, seatId) {
+  const res = http.post(
+    `${BASE_URL}/reservations`,
+    JSON.stringify({
+      scheduleId,
+      seatId,
+    }),
+    {
+      tags: { name: '좌석 예약' },
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `${token}`,
+      },
+    },
+  );
+  check(res, { '좌석 예약': (r) => r.status === 201 });
+
+  if (res.status === 201) {
+    return res.json()['id'];
+  }
+  return null;
+}
+
+/**
+ * 포인트 충전
+ */
+function chargePoint(userId, amount) {
+  const res = http.patch(
+    `${BASE_URL}/users/${userId}/point/charge`,
+    JSON.stringify({
+      amount,
+    }),
+    {
+      tags: { name: '포인트 충전' },
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    },
+  );
+  check(res, { '포인트 충전': (r) => r.status === 200 });
+
+  return res.status === 200;
+}
+
+/**
+ * 좌석 결제
+ */
+function pay(token, reservationId) {
+  const res = http.post(
+    `${BASE_URL}/payments`,
+    JSON.stringify({
+      reservationId,
+    }),
+    {
+      tags: { name: '좌석 결제' },
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `${token}`,
+      },
+    },
+  );
+  check(res, { '좌석 결제': (r) => r.status === 201 });
+  return res.status === 201;
+}

--- a/src/3-domain/queue/queue.service.ts
+++ b/src/3-domain/queue/queue.service.ts
@@ -11,18 +11,11 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
-import Redlock from 'redlock';
-import Redis from 'ioredis';
-import { InjectRedis } from '@liaoliaots/nestjs-redis';
 import { QueueRedisRepository } from 'src/4-infrastructure/queue/queue-redis.repository';
 
 @Injectable()
 export class QueueService {
-  constructor(
-    @InjectRedis()
-    private readonly redis: Redis,
-    private readonly queueRedisRepository: QueueRedisRepository,
-  ) {}
+  constructor(private readonly queueRedisRepository: QueueRedisRepository) {}
 
   /**
    * Redis의 패턴을 이용해 queue 조회
@@ -49,8 +42,8 @@ export class QueueService {
   }
 
   async create(args: QueueServiceCreateProps): Promise<QueueModel> {
-    const redlock = new Redlock([this.redis]);
-    const lock = await redlock.acquire(['queue'], 2000);
+    // const redlock = new Redlock([this.redis]);
+    // const lock = await redlock.acquire(['queue'], 2000);
 
     let queue = await this.getQueueByPattern(`*:${args.userId}:*`);
 
@@ -68,7 +61,7 @@ export class QueueService {
         await this.queueRedisRepository.getRankByValueFromWaitingQueue(value);
     }
 
-    await lock.release();
+    // await lock.release();
 
     return queue;
   }

--- a/src/4-infrastructure/concerts/entities/concert-schedule.entity.ts
+++ b/src/4-infrastructure/concerts/entities/concert-schedule.entity.ts
@@ -1,6 +1,7 @@
-import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity('concert_schedule')
+@Index(['ticketOpenAt', 'ticketCloseAt'])
 export class ConcertScheduleEntity {
   @PrimaryGeneratedColumn()
   id: number;

--- a/src/4-infrastructure/concerts/entities/concert-seat.entity.ts
+++ b/src/4-infrastructure/concerts/entities/concert-seat.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
 
 export enum ConcertSeatStatusEnum {
   CLOSED = 'closed',
@@ -8,6 +8,7 @@ export enum ConcertSeatStatusEnum {
 }
 
 @Entity('concert_seat')
+@Index(['concertScheduleId'])
 export class ConcertSeatEntity {
   @PrimaryGeneratedColumn()
   id: number;


### PR DESCRIPTION
# [부하테스트 시나리오 및 개선사항](https://github.com/Ksanbal/Concert-Reservation-API/tree/steps/step19?tab=readme-ov-file#부하테스트-시나리오-및-개선사항)
## 부하테스트 시나리오
대기열 시스템이 있기 때문에 일련의 시나리오를 통한 부하테스트를 진행

### 시나리오
1. 대기열 진입 및 대기
2. 공연 목록, 해당 공연의 좌석 목록 조회
3. 좌석 예약 요청
4. 결제를 위한 포인트 충전 요청
5. 예약한 좌석에 대한 결제 요청

### 설정환경
- 초반 10초안으로 모든 유저 요청 시작
- 5분간 유저수 유지
- 5분 이후 점차적으로 활성 유저수 감소

## 부하테스트 결과 (개선전(실선) / 개선후(점선))
<img alt="image" src="https://github.com/user-attachments/assets/15fba89d-2de8-40ae-aca0-2f56e9ed9493">
<img alt="image" src="https://github.com/user-attachments/assets/751a2b85-a65c-4bfb-97d0-35ce4c828568">
<img alt="image" src="https://github.com/user-attachments/assets/afe64313-12b3-41ec-9275-7a5dfa3911b6">

## 개선사항
### 대기열
- 이슈
  - 대기열 토큰 발급시 분산락으로 인한 응답지연 이슈
  - 분산락 획득 실패로 인한 에러 발생
- `분산락 코드 삭제로 불필요한 지연 제거`
- <img alt="image" src="https://github.com/user-attachments/assets/b2b66d6d-9100-4f20-817e-596ae27be4f2"><img alt="image" src="https://github.com/user-attachments/assets/45c8adc6-2e64-4e4a-adbb-b964b622e35f"> (좌측 개선전 / 우측 개선 후)
- 오류 발생 삭제 및 응답 속도 개선
  - 토큰 발급 (평균) : 2s -> 462ms (332%)
  - 

### 좌석 목록 조회
- Index를 통한 쿼리 조회 개선
- <img alt="image" src="https://github.com/user-attachments/assets/b2b66d6d-9100-4f20-817e-596ae27be4f2"><img alt="image" src="https://github.com/user-attachments/assets/198e95c4-076d-4617-a2e6-b2d2e7913f96"> (좌측 개선전 / 우측 개선 후)
- 오류 발생 삭제
- min, max 반환속도 개선

### 예약 & 결제
- 예약에 분산락을 추가하여 DB Lock 줄이기
- <img alt="image" src="https://github.com/user-attachments/assets/b2b66d6d-9100-4f20-817e-596ae27be4f2"><img alt="image" src="https://github.com/user-attachments/assets/60f1386f-1bdd-408b-a1a9-451e7e36c35c">
- 성공시 응답시간 개선
  - 좌석 예약 (평균) : 3s -> 141ms (2000%)
  - 좌석 결제 (평균) : 688ms -> 353ms (94%)